### PR TITLE
urlparser function

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,13 @@ module.exports = function (db, opts) {
 
   opts = opts || {}
   var sep = opts.sep || '\x00'
+  var urlparser = opts.urlparser || function(str) { return str }
+
   return function (req, res, next) {
-
-    var url = isDir(req.url) ? req.url + 'index.html' : req.url
+    
+    var url = isDir(req.url) ? urlparser(req.url) + 'index.html' : urlparser(req.url)
     var key = split(url).join('\x00')
-
+    
     function respond (err, data) {
       if(err) {
         if(next) return next(err)

--- a/test/test.js
+++ b/test/test.js
@@ -31,8 +31,8 @@ tape('simple test', function (t) {
 })
 
 tape('large file', function (t) {
-
-  var server = http.createServer(static(db)).listen(port, function () {
+  
+   var server = http.createServer(static(db)).listen(port, function () {
 
     var d3 = '', l = 0
     var put = request.put(url('d3.v2.js'))
@@ -53,4 +53,34 @@ tape('large file', function (t) {
       })
     })
   })
+})
+
+tape('url parser option', function (t) {
+  	
+  var opt = {};
+  opt.urlparser = function(url){
+  	return url.split('?')[0]
+  }
+  var server = http.createServer(static(db, opt)).listen(port, function () {
+
+    var d3 = '', l = 0
+    var put = request.put(url('urlparser.js?aparam=hello'))
+
+    fs.createReadStream(__dirname + '/fixtures/d3.v2.js', 'utf-8')
+    .on('data', function (data) {
+      d3 += data.toString()
+      l += data.length
+    })
+    .pipe(put)
+
+    put.on('end', function () {
+      request(url('urlparser.js'), function (err, _, body) {
+        if(err) throw err
+        t.equal(body, d3)
+        server.close()
+        t.end()
+      })
+    })
+  })
+
 })


### PR DESCRIPTION
Allow a function to be passed in the options so that a server will not save the document under a key that includes the querystring parameters. 
Default is to still save the query string 

Also referenced in issue https://github.com/dominictarr/level-static/issues/3

See test 'url parser option' 
